### PR TITLE
chore: 🧹 Resolve Docker Artifact Registry problem (autofix)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,11 +13,11 @@ workflows:
       - gcp-gcr/build-and-push-image:
           name: Build Image
           executor: build
-          context: gcp-oidc-docker-registry
+          context: gcp-oidc-artifact-registry
           dockerfile: Dockerfile
-          registry-url: eu.gcr.io
+          registry-url: europe-west1-docker.pkg.dev
           use_oidc: true
-          image: certspotter
+          image: docker/certspotter
           tag: ${CIRCLE_SHA1}
           # https://circleci.com/docs/2.0/building-docker-images/#docker-version
           remote-docker-version: default


### PR DESCRIPTION
### Check description:
Migrates our Docker images from Google Container Registry to Google Artifact Registry.

JIRA ticket: [BP-2182](https://forto.atlassian.net/browse/BP-2182)

### Problem summary:
Deployment pipeline uses legacy GCR

> Google Container Registry is being shut down by next year. We are migrating to Google Artifact Registry.

#### In `.circleci/config.yml`:
* Use Google Artifact Registry for docker artifacts. (line 18)
* Use Google Artifact Registry for docker artifacts. (line 20)
* Use our new project for docker artifacts. (line 16)

### :broom: Authored using Repo Nanny
https://repo-nanny.forto.tools/repos/certspotter

[BP-2182]: https://forto.atlassian.net/browse/BP-2182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ